### PR TITLE
Middleware to Request and Parse Spotify Playlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
+
 dist/
 node_modules/
+samples/

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,13 @@
         "qs": "6.5.2",
         "raw-body": "2.3.3",
         "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "boxen": {
@@ -650,6 +657,13 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "extend-shallow": {
@@ -1886,6 +1900,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
     "nodemon": {
       "version": "1.18.6",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
@@ -2109,9 +2128,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
     "range-parser": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "homepage": "https://github.com/vartanovs/seanify#readme",
   "dependencies": {
     "dotenv": "^6.1.0",
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+    "node-fetch": "^2.3.0",
+    "qs": "^6.6.0"
   },
   "devDependencies": {
     "nodemon": "^1.18.6"

--- a/src/server/controllers/spotifyController.js
+++ b/src/server/controllers/spotifyController.js
@@ -10,54 +10,104 @@ const qs = require('qs');
 // Access dotenv for Spotify token
 require('dotenv').config();
 
-const getAuthCode = (req, res, next) => {
-  const scopes = 'playlist-read-private';
-  res.locals.redirectUrl = `https://accounts.spotify.com/authorize?response_type=code&client_id=${process.env.SPOT_CLIENT_ID}&scope=${encodeURIComponent(scopes)}&redirect_uri=${encodeURIComponent('http://localhost:3000/spotify-callback/')}`;
+/**
+ * Middleware to generate Spotify redirect URL to retrieve User Authorization
+ * @param {Request} _ Express HTTP Request Object
+ * @param {Response} res Express HTTP Response Object
+ * @param {*} next Express Function to Call Next Middleware
+ */
+const getAuthCode = (_, res, next) => {
+  // Set scope of access that user will grant our application and generate URL
+  const scope = 'playlist-read-private';
+  res.locals.redirectUrl = `https://accounts.spotify.com/authorize?response_type=code&client_id=${process.env.SPOT_CLIENT_ID}&scope=${encodeURIComponent(scope)}&redirect_uri=${encodeURIComponent(process.env.SPOT_REDIRECT_URI)}`;
   return next();
 };
 
-const getToken = (req, res, next) => {
+/**
+ * Middleware to Retrieve User Access Token with Code Query Parameter
+ * @param {Request} req Express HTTP Request Object
+ * @param {Response} res Express HTTP Response Object
+ * @param {*} next Express Function to Call Next Middleware
+ */
+const getAuthToken = (req, res, next) => {
   fetch('https://accounts.spotify.com/api/token', {
     method: 'POST',
     headers: {
+      Authorization: `Basic ${Buffer.from(`${process.env.SPOT_CLIENT_ID}:${process.env.SPOT_CLIENT_SECRET}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: qs.stringify({
-      grant_type: 'client_credentials',
-      client_id: process.env.SPOT_CLIENT_ID,
-      client_secret: process.env.SPOT_CLIENT_SECRET,
+      grant_type: 'authorization_code',
+      code: req.query.code,
+      redirect_uri: process.env.SPOT_REDIRECT_URI,
     }),
   })
     .then(data => data.json())
     .then((data) => {
-      res.locals.spotifyToken = data.access_token;
+      // Store User Access Token in res.locals
+      res.locals.spotifyUserToken = data.access_token;
       return next();
     })
     .catch(spotErr => console.error('Error: Could Not Retrieve Token From Spotify: ', spotErr));
 };
 
-const getAuthToken = (req, res, next) => {
-  
-}
+/**
+ * Middleware to Retrieve Spotify Playlist Data with User Access Token
+ * @param {Request} _ Express HTTP Request Object
+ * @param {Response} res Express HTTP Response Object
+ * @param {*} next Express Function to Call Next Middleware
+ */
+const getUserPlaylists = (_, res, next) => {
+  // Generate endpoint string, including query parameter to indicate # of playlists to request
+  const spotURL = new URL('https://api.spotify.com/v1/me/playlists');
+  // Query parameter can be between 1 and 50
+  const queryParams = { limit: 25 };
+  spotURL.search = new URLSearchParams(queryParams);
 
-const getPlaylists = (req, res, next) => {
-  fetch('https://api.spotify.com//v1/me/playlists', {
+  fetch(spotURL, {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${res.locals.spotifyToken}`,
+      Authorization: `Bearer ${res.locals.spotifyUserToken}`,
+      'Content-Type': 'application/json',
     },
   })
     .then(data => data.json())
     .then((data) => {
-      res.locals.data = data;
+      // Store Spotify Playlist Data in res.locals
+      res.locals.playlists = data;
       return next();
     })
-    .catch(spotErr => console.error('Error: Could Not Retrieve Playlists From Spotify: ', spotErr));
+    .catch(spotErr => console.error('Error: Could Not Retrieve User Profile From Spotify: ', spotErr));
+};
+
+/**
+ * Middleware to Parse Spotify Playlist Data, return array of parsed objects
+ * @param {Request} _ Express HTTP Request Object
+ * @param {Response} res Express HTTP Response Object
+ * @param {*} next Express Function to Call Next Middleware
+ */
+const parseUserPlaylists = (_, res, next) => {
+  // Store Parsed Playlist Objects in res.locals Array
+  res.locals.parsedPlaylists = [];
+  // Parse each item in the playlist object retrieved from Spotify
+  res.locals.playlists.items.forEach((playlist) => {
+    const imageUri = playlist.images.length ? playlist.images[0].url : '';
+    return res.locals.parsedPlaylists.push({
+      playlistId: playlist.id,
+      playlistName: playlist.name,
+      playlistUri: playlist.external_urls.spotify,
+      ownerName: playlist.owner.display_name,
+      ownerUri: playlist.owner.external_urls.spotify,
+      tracks: playlist.tracks.total,
+      imageUri,
+    });
+  });
+  return next();
 };
 
 module.exports = {
   getAuthCode,
   getAuthToken,
-  getPlaylists,
-  getToken,
+  getUserPlaylists,
+  parseUserPlaylists,
 };

--- a/src/server/controllers/spotifyController.js
+++ b/src/server/controllers/spotifyController.js
@@ -1,0 +1,63 @@
+/**
+ * @module spotifyController.js
+ * @description Middleware for Spotify API
+ */
+
+// Dependencies: Fetch and Query String Parsing
+const fetch = require('node-fetch');
+const qs = require('qs');
+
+// Access dotenv for Spotify token
+require('dotenv').config();
+
+const getAuthCode = (req, res, next) => {
+  const scopes = 'playlist-read-private';
+  res.locals.redirectUrl = `https://accounts.spotify.com/authorize?response_type=code&client_id=${process.env.SPOT_CLIENT_ID}&scope=${encodeURIComponent(scopes)}&redirect_uri=${encodeURIComponent('http://localhost:3000/spotify-callback/')}`;
+  return next();
+};
+
+const getToken = (req, res, next) => {
+  fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: qs.stringify({
+      grant_type: 'client_credentials',
+      client_id: process.env.SPOT_CLIENT_ID,
+      client_secret: process.env.SPOT_CLIENT_SECRET,
+    }),
+  })
+    .then(data => data.json())
+    .then((data) => {
+      res.locals.spotifyToken = data.access_token;
+      return next();
+    })
+    .catch(spotErr => console.error('Error: Could Not Retrieve Token From Spotify: ', spotErr));
+};
+
+const getAuthToken = (req, res, next) => {
+  
+}
+
+const getPlaylists = (req, res, next) => {
+  fetch('https://api.spotify.com//v1/me/playlists', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${res.locals.spotifyToken}`,
+    },
+  })
+    .then(data => data.json())
+    .then((data) => {
+      res.locals.data = data;
+      return next();
+    })
+    .catch(spotErr => console.error('Error: Could Not Retrieve Playlists From Spotify: ', spotErr));
+};
+
+module.exports = {
+  getAuthCode,
+  getAuthToken,
+  getPlaylists,
+  getToken,
+};

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,32 +3,25 @@
  * @description Entry Point for Server
  */
 
+// Import Express to activate server
 const express = require('express');
 
-const PORT = 3000;
-
 const app = express();
+const PORT = 3000;
 
 // Import Middleware to interface with Spotify API
 const spotifyController = require('./controllers/spotifyController');
 
-// GET Route - Get Spotify Authorization
+// GET Route - Get Spotify Authorization Code
 app.get('/spotify-login',
   spotifyController.getAuthCode,
   (req, res) => res.redirect(res.locals.redirectUrl));
 
-// GET Route - Get Spotify Authorization
+// GET Route - Get Spotify Token > Retreive and Parse Playlists > Return Parsed Playlists
 app.get('/callback/spotify',
   spotifyController.getAuthToken,
-  (req, res) => {
-    console.log(req.body);
-    res.sendStatus(200);
-  });
-
-// POST Route - Get Spotify Playlist
-app.post('/get-spotify-playlist',
-  spotifyController.getToken,
-  spotifyController.getPlaylists,
-  (req, res) => res.status(200).json(res.locals));
+  spotifyController.getUserPlaylists,
+  spotifyController.parseUserPlaylists,
+  (req, res) => res.status(200).json(res.locals.parsedPlaylists));
 
 app.listen(PORT, () => console.log(`Server Listening on PORT: ${PORT}`));

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,4 +9,26 @@ const PORT = 3000;
 
 const app = express();
 
+// Import Middleware to interface with Spotify API
+const spotifyController = require('./controllers/spotifyController');
+
+// GET Route - Get Spotify Authorization
+app.get('/spotify-login',
+  spotifyController.getAuthCode,
+  (req, res) => res.redirect(res.locals.redirectUrl));
+
+// GET Route - Get Spotify Authorization
+app.get('/callback/spotify',
+  spotifyController.getAuthToken,
+  (req, res) => {
+    console.log(req.body);
+    res.sendStatus(200);
+  });
+
+// POST Route - Get Spotify Playlist
+app.post('/get-spotify-playlist',
+  spotifyController.getToken,
+  spotifyController.getPlaylists,
+  (req, res) => res.status(200).json(res.locals));
+
 app.listen(PORT, () => console.log(`Server Listening on PORT: ${PORT}`));


### PR DESCRIPTION
* '/login-spotify' prompts user to authorize Seanify to access Spotify Playlists
* Above route redirects to '/callback/spotify' with Auth Code in query parameter
* Request is issued to spotify to secure User Authorization Token
* Token is used to request Playlist data
* Playlist data parsed to the following shape for frontend:
[
  {
    "playlistId": string,
    "playlistName": string,
    "playlistUri": string,
    "ownerName": string,
    "ownerUri": string,
    "tracks": number,
    "imageUri": string,
  },
]